### PR TITLE
Adjustment to processing

### DIFF
--- a/analytics/dbrks_nhs_app/dbrks_nhs_app_registered_population_week_prop.py
+++ b/analytics/dbrks_nhs_app/dbrks_nhs_app_registered_population_week_prop.py
@@ -93,13 +93,11 @@ df_ref = pd.read_parquet(io.BytesIO(file), engine="pyarrow")
 #Numerator
 # ---------------------------------------------------------------------------------------------------
 df['Date'] = pd.to_datetime(df['Date'], infer_datetime_format=True)  
-print(df['Date'].max())
 df.rename(columns = {'AcceptedTermsAndConditions':'users'}, inplace = True)
 df2 = df[['Date','users']].copy()
 df2['users'] = pd.to_numeric(df2['users'],errors='coerce').fillna(0)
+df2.drop(df2[df2['Date'] < '2021-01-01'].index, inplace = True) #--------- remove rows pre 2021
 df2 = df2.groupby('Date').sum().resample('W').sum()
-df2.drop(df2[df2['users'] == 0].index,inplace=True) #--------- remove columns with 0
-df2.iloc[0,:]['users'] += 1050398 #--------- adjustment for missing history
 df2['total_users'] = df2['users'].cumsum() #--------- add cumulative sum column
 
 #Denominator porcessing

--- a/ingestion/dbrks_nhs_app/dbrks_nhs_app_usage_raw.py
+++ b/ingestion/dbrks_nhs_app/dbrks_nhs_app_usage_raw.py
@@ -80,7 +80,7 @@ sink_file = config_JSON['pipeline']['raw']['appended_file']
 # -------------------------
 latestFolder = datalake_latestFolder(CONNECTION_STRING, file_system, new_source_path)
 file_name_list = datalake_listContents(CONNECTION_STRING, file_system, new_source_path+latestFolder)
-file_name_list = [file for file in file_name_list if '.csv' in file]
+file_name_list = [file for file in file_name_list if 'nhs_app_table_snapshot' in file]
 for new_source_file in file_name_list:
   new_dataset = datalake_download(CONNECTION_STRING, file_system, new_source_path+latestFolder, new_source_file)
   new_dataframe = pd.read_csv(io.BytesIO(new_dataset))


### PR DESCRIPTION
**Two changes:**

1 - NHS App Registrations processing notebook
Made decision to not adjust for missing history as there is not a way to know if it is being done accurately. Instead, will use data only from 2021 onwards, and add caveat to dashboard. 

Added code to filter pre 2021 data out
Removed code to adjust for missing history
Removed code to remove rows with zero users

2 - NHS App ingestion notebook
Script now filters files in landing blob by filename (excluding timestamp), rather than with csv extension. 