### PR TITLE
bug fix: date moving around NHSD webpage

### DIFF
--- a/ingestion/dbrks_gp_records_api/dbrks_gp_records_api_raw.py
+++ b/ingestion/dbrks_gp_records_api/dbrks_gp_records_api_raw.py
@@ -84,8 +84,8 @@ sink_file = config_JSON['pipeline']['raw']['appended_file']
 url = "https://digital.nhs.uk/services/gp-connect/deployment-and-utilisation"
 response = urllib.request.urlopen(url)
 soup = BeautifulSoup(response.read(), "lxml")
-data = soup.findAll("p",attrs={"class": "nhsd-t-body",},)[2].text
-latestDate = search_dates(data)
+date_data = soup.find(lambda tag:tag.name=="p" and "date" in tag.text)
+latestDate = search_dates(date_data.text)
 date = latestDate[0][1].strftime("%Y-%m-%d")
 results = []
 for pp in soup.select("div.nhsd-m-infographic__headline-box"):


### PR DESCRIPTION
Using a lambda function to search for "p" elements in the NHSD webpage which contain the date keyword to mitigate the issue of the date being shifted around the page, which the .findAll combined with selecting the specific element of the resulting list with the date couldn't handle - resulting in webscraping script breaking.

@danjscho - any additional suggestions are welcome.